### PR TITLE
Fix docs for output-file-name flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vimeo-dl -i "https://8vod-adaptive.akamaized.net/xxx/yyy/sep/video/9f88d1ff,b83d
          --video-id "b83d0f9d" \
          --audio-id "b83d0f9d" \
          --combine \
-         --output "my-video-file-name"
+         --output-file-name "my-video-file-name"
 
 # The combine option is equivalent to the following command.
 vimeo-dl -i "https://8vod-adaptive.akamaized.net/xxx/yyy/sep/video/9f88d1ff,b83d0f9d,da44206b,f34fd50d,f9ebc26f/master.json?base64_init=1" \
@@ -54,14 +54,14 @@ Usage:
   vimeo-dl [flags]
 
 Flags:
-      --audio-id string     audio id
-      --combine             combine video and audio into a single mp4 (ffmpeg is required)
-  -h, --help                help for vimeo-dl
-  -i, --input string        url for master.json (required)
-  -o, --output string       output file name
-      --user-agent string   user-agent for request
-  -v, --version             version for vimeo-dl
-      --video-id string     video id
+      --audio-id string           audio id
+      --combine                   combine video and audio into a single mp4 (ffmpeg is required)
+  -h, --help                      help for vimeo-dl
+  -i, --input string              url for master.json (required)
+  -o, --output-file-name string   output file name
+      --user-agent string         user-agent for request
+  -v, --version                   version for vimeo-dl
+      --video-id string           video id
 ```
 
 ## Install


### PR DESCRIPTION
The README.md file currently shows `--output` as an available flag, but it is implemented as `--output-file-name`. This PR corrects the docs and examples to match the actual implementation.